### PR TITLE
removed set connected to YES on connect

### DIFF
--- a/MQTTKit/MQTTKit.m
+++ b/MQTTKit/MQTTKit.m
@@ -232,8 +232,6 @@ static void on_unsubscribe(struct mosquitto *mosq, void *obj, int message_id)
         mosquitto_loop_forever(mosq, 10, 1);
         LogDebug(@"end mosquitto loop");
     });
-
-    self.connected = YES;
 }
 
 - (void)connectToHost:(NSString *)host


### PR DESCRIPTION
Removed the `self.connected = YES;` from the `connectWithCompletionHandler` method, this property will be set by the `on_connect` method. It makes sense to only be set when a successful connection with the server is established and not before.
