### PR TITLE
Fix potential memory issue for applications with high throughput.

### DIFF
--- a/MQTTKit/MQTTKit.m
+++ b/MQTTKit/MQTTKit.m
@@ -117,17 +117,22 @@ static void on_publish(struct mosquitto *mosq, void *obj, int message_id)
 
 static void on_message(struct mosquitto *mosq, void *obj, const struct mosquitto_message *mosq_msg)
 {
-    NSString *topic = [NSString stringWithUTF8String: mosq_msg->topic];
-    NSData *payload = [NSData dataWithBytes:mosq_msg->payload length:mosq_msg->payloadlen];
-    MQTTMessage *message = [[MQTTMessage alloc] initWithTopic:topic
-                                                      payload:payload
-                                                          qos:mosq_msg->qos
-                                                       retain:mosq_msg->retain
-                                                          mid:mosq_msg->mid];
-    MQTTClient* client = (__bridge MQTTClient*)obj;
-    LogDebug(@"[%@] on message %@", client.clientID, message);
-    if (client.messageHandler) {
-        client.messageHandler(message);
+    // Ensure these objects are cleaned up quickly by an autorelease pool.
+    // The GCD autorelease pool isn't guaranteed to clean this up in any amount of time.
+    // Source: https://developer.apple.com/library/ios/DOCUMENTATION/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html#//apple_ref/doc/uid/TP40008091-CH102-SW1
+    @autoreleasepool {
+        NSString *topic = [NSString stringWithUTF8String: mosq_msg->topic];
+        NSData *payload = [NSData dataWithBytes:mosq_msg->payload length:mosq_msg->payloadlen];
+        MQTTMessage *message = [[MQTTMessage alloc] initWithTopic:topic
+                                                          payload:payload
+                                                              qos:mosq_msg->qos
+                                                           retain:mosq_msg->retain
+                                                              mid:mosq_msg->mid];
+        MQTTClient* client = (__bridge MQTTClient*)obj;
+        LogDebug(@"[%@] on message %@", client.clientID, message);
+        if (client.messageHandler) {
+            client.messageHandler(message);
+        }
     }
 }
 


### PR DESCRIPTION
I'm seeing significant memory growth when receiving messages. I'm testing with a lot of sizable messages, which likely exasperates the issue...But it should still be there for less intensive use cases, just less pronounced. Digging into the cause, I found:

> If your block creates more than a few Objective-C objects, you might want to enclose parts of your block’s code in an @autorelease block to handle the memory management for those objects. Although GCD dispatch queues have their own autorelease pools, they make no guarantees as to when those pools are drained. If your application is memory constrained, creating your own autorelease pool allows you to free up the memory for autoreleased objects at more regular intervals.
> **Source: [Apple Concurrency Programming Guide](https://developer.apple.com/library/ios/DOCUMENTATION/General/Conceptual/ConcurrencyProgrammingGuide/OperationQueues/OperationQueues.html#//apple_ref/doc/uid/TP40008091-CH102-SW1)**

If my understanding is correct, `on_message()` in **MQTTKit.m** is being run on the `dispatch_queue`, which has an autorelease pool that doesn't seem to be draining, at least not often enough. Simply wrapping the `on_message` method with an autorelease pool fixed it up just fine though.
