### PR TITLE
Fix OSX deployment target requirement

### DIFF
--- a/MQTTKit.podspec
+++ b/MQTTKit.podspec
@@ -6,10 +6,11 @@ Pod::Spec.new do |s|
   s.homepage     = "http://github.com/jmesnil/MQTTKit"
   s.license      = { :type => 'Apache License, Version 2.0', :file => 'LICENSE' }
   s.author       = { "Jeff Mesnil" => "jmesnil@gmail.com" }
-  s.ios.platform = :ios, '6.0'
+
   # for using GCD queue as Objective-C objects
-  s.ios.deployment_target = "6.0"
-  s.osx.platform = :osx, '10.9'
+  s.ios.deployment_target = '6.0'
+  s.osx.deploymnet_target = '10.9'
+  
   s.source       = { :git => "https://github.com/jmesnil/MQTTKit.git", :tag => "#{s.version}" }
 
   s.source_files  = 'libmosquitto/*.{h,c}', 'MQTTKit/*.{h,m}'

--- a/MQTTKit.podspec
+++ b/MQTTKit.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
 
   # for using GCD queue as Objective-C objects
   s.ios.deployment_target = '6.0'
-  s.osx.deploymnet_target = '10.9'
+  s.osx.deployment_target = '10.9'
   
   s.source       = { :git => "https://github.com/jmesnil/MQTTKit.git", :tag => "#{s.version}" }
 


### PR DESCRIPTION
I updated the podspec to allow using the library for OSX applications with the latest cocoapods release. (I set the same settings as AFNetworking is using)